### PR TITLE
Add mime groups

### DIFF
--- a/tests/test_foo.py
+++ b/tests/test_foo.py
@@ -1,2 +1,0 @@
-def test_foo():
-    assert True

--- a/tests/test_mimegroups.py
+++ b/tests/test_mimegroups.py
@@ -1,0 +1,56 @@
+from xtractmime.mimegroups import (
+    is_archive_mime_type,
+    is_audio_video_mime_type,
+    is_font_mime_type,
+    is_html_mime_type,
+    is_image_mime_type,
+    is_javascript_mime_type,
+    is_json_mime_type,
+    is_scriptable_mime_type,
+    is_xml_mime_type,
+    is_zip_based_mime_type,
+)
+
+
+class TestMimegroups:
+    def test_is_archive_mime_type(self):
+        assert is_archive_mime_type(b"application/zip")
+        assert not is_archive_mime_type(b"text/test")
+
+    def test_is_audio_video_mime_type(self):
+        assert is_audio_video_mime_type(b"video/mp4")
+        assert not is_audio_video_mime_type(b"text/test")
+
+    def test_is_font_mime_type(self):
+        assert is_font_mime_type(b"application/font-cff")
+        assert not is_font_mime_type(b"text/test")
+
+    def test_is_html_mime_type(self):
+        assert is_html_mime_type(b"text/html")
+        assert not is_html_mime_type(b"text/test")
+
+    def test_is_image_mime_type(self):
+        assert is_image_mime_type(b"image/gif")
+        assert not is_image_mime_type(b"text/test")
+
+    def test_is_javascript_mime_type(self):
+        assert is_javascript_mime_type(b"application/javascript")
+        assert not is_javascript_mime_type(b"text/test")
+
+    def test_is_json_mime_type(self):
+        assert is_json_mime_type(b"text/json")
+        assert not is_json_mime_type(b"text/test")
+
+    def test_is_scriptable_mime_type(self):
+        assert is_scriptable_mime_type(b"text/html")
+        assert is_scriptable_mime_type(b"text/xml")
+        assert is_scriptable_mime_type(b"application/pdf")
+        assert not is_scriptable_mime_type(b"text/test")
+
+    def test_is_xml_mime_type(self):
+        assert is_xml_mime_type(b"text/xml")
+        assert not is_xml_mime_type(b"text/test")
+
+    def test_is_zip_based_mime_type(self):
+        assert is_zip_based_mime_type(b"application/zip")
+        assert not is_zip_based_mime_type(b"text/test")

--- a/tests/test_mimegroups.py
+++ b/tests/test_mimegroups.py
@@ -14,10 +14,14 @@ ALL_MIME_GROUPS = {
     "mime_type,mime_groups",
     [
         (b"image/foo", {"image"}),
+        (b"image/x-icon", {"image"}),
         (b"audio/foo", {"audio_video"}),
+        (b"audio/basic", {"audio_video"}),
         (b"video/foo", {"audio_video"}),
+        (b"video/avi", {"audio_video"}),
         (b"application/ogg", {"audio_video"}),
         (b"font/foo", {"font"}),
+        (b"application/vnd.ms-fontobject", {"font"}),
         (b"application/font-cff", {"font"}),
         (b"application/foo+zip", {"zip"}),
         (b"application/zip", {"zip", "archive"}),
@@ -29,6 +33,9 @@ ALL_MIME_GROUPS = {
         (b"application/ecmascript", {"javascript"}),
         (b"application/foo+json", {"json"}),
         (b"text/json", {"json"}),
+        (b"application/postscript", {"text"}),
+        (b"text/plain", {"text"}),
+        (b"text/plain; charset=ISO-8859-1", {"text"}),
     ],
 )
 def test_mime_group(mime_type, mime_groups):

--- a/tests/test_mimegroups.py
+++ b/tests/test_mimegroups.py
@@ -13,30 +13,127 @@ ALL_MIME_GROUPS = {
 @pytest.mark.parametrize(
     "mime_type,mime_groups",
     [
+        # MIME type types
         (b"image/foo", {"image"}),
-        (b"image/x-icon", {"image"}),
         (b"audio/foo", {"audio_video"}),
-        (b"audio/basic", {"audio_video"}),
         (b"video/foo", {"audio_video"}),
-        (b"video/avi", {"audio_video"}),
-        (b"application/ogg", {"audio_video"}),
         (b"font/foo", {"font"}),
-        (b"application/vnd.ms-fontobject", {"font"}),
-        (b"application/font-cff", {"font"}),
+        # MIME types subtype suffixes
         (b"application/foo+zip", {"zip"}),
+        (b"application/foo+xml", {"xml", "scriptable"}),
+        (b"application/foo+json", {"json"}),
+        # 4.6. MIME type groups, audio or video MIME type
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#audio-or-video-mime-type
+        (b"application/ogg", {"audio_video"}),
+        # 4.6. MIME type groups, font MIME type
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#font-mime-type
+        (b"application/font-cff", {"font"}),
+        (b"application/font-off", {"font"}),
+        (b"application/font-sfnt", {"font"}),
+        (b"application/font-ttf", {"font"}),
+        (b"application/font-woff", {"font"}),
+        (b"application/vnd.ms-fontobject", {"font"}),
+        (b"application/vnd.ms-opentype", {"font"}),
+        # 4.6. MIME type groups, zip-based MIME type
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#zip-based-mime-type
+        (b"application/zip", {"zip", "archive"}),
+        # 4.6. MIME type groups, archive MIME type
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#archive-mime-type
+        (b"application/x-rar-compressed", {"archive"}),
         (b"application/zip", {"zip", "archive"}),
         (b"application/x-gzip", {"archive"}),
-        (b"application/foo+xml", {"xml", "scriptable"}),
+        # 4.6. MIME type groups, xml MIME type
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#xml-mime-type
         (b"text/xml", {"xml", "scriptable"}),
+        (b"application/xml", {"xml", "scriptable"}),
+        # 4.6. MIME type groups, html MIME type
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#html-mime-type
         (b"text/html", {"html", "scriptable"}),
+        # 4.6. MIME type groups, scriptable MIME type
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#scriptable-mime-type
         (b"application/pdf", {"scriptable"}),
+        # 4.6. MIME type groups, javascript MIME type
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#javascript-mime-type
         (b"application/ecmascript", {"javascript"}),
-        (b"application/foo+json", {"json"}),
+        (b"application/javascript", {"javascript"}),
+        (b"application/x-ecmascript", {"javascript"}),
+        (b"application/x-javascript", {"javascript"}),
+        (b"text/ecmascript", {"javascript"}),
+        (b"text/javascript", {"javascript"}),
+        (b"text/javascript1.0", {"javascript"}),
+        (b"text/javascript1.1", {"javascript"}),
+        (b"text/javascript1.2", {"javascript"}),
+        (b"text/javascript1.3", {"javascript"}),
+        (b"text/javascript1.4", {"javascript"}),
+        (b"text/javascript1.5", {"javascript"}),
+        (b"text/jscript", {"javascript"}),
+        (b"text/livescript", {"javascript"}),
+        (b"text/x-ecmascript", {"javascript"}),
+        (b"text/x-javascript", {"javascript"}),
+        # 4.6. MIME type groups, json MIME type
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#json-mime-type
+        (b"application/json", {"json"}),
         (b"text/json", {"json"}),
-        (b"application/postscript", {"text"}),
+        # 5.1. Interpreting resource metadata
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#interpreting-the-resource-metadata
         (b"text/plain", {}),
         (b"text/plain; charset=ISO-8859-1", {}),
+        (b"text/plain; charset=iso-8859-1", {}),
+        (b"text/plain; charset=UTF-8", {}),
+        # 6.1. Matching an image type pattern
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#matching-an-image-type-pattern
+        (b"image/x-icon", {"image"}),
+        (b"image/bmp", {"image"}),
+        (b"image/gif", {"image"}),
+        (b"image/webp", {"image"}),
+        (b"image/png", {"image"}),
+        (b"image/jpeg", {"image"}),
+        # 6.2. Matching an audio or video type pattern
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#matching-an-audio-or-video-type-pattern
+        (b"audio/basic", {"audio_video"}),
+        (b"audio/aiff", {"audio_video"}),
+        (b"audio/mpeg", {"audio_video"}),
+        (b"application/ogg", {"audio_video"}),
+        (b"audio/midi", {"audio_video"}),
+        (b"video/avi", {"audio_video"}),
+        (b"audio/wave", {"audio_video"}),
+        (b"video/mp4", {"audio_video"}),
+        (b"video/webm", {"audio_video"}),
+        (b"audio/mpeg", {"audio_video"}),
+        # 6.3. Matching a font type pattern
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#matching-a-font-type-pattern
+        (b"application/vnd.ms-fontobject", {"font"}),
+        (b"font/ttf", {"font"}),
+        (b"font/otf", {"font"}),
+        (b"font/collection", {"font"}),
+        (b"font/woff", {"font"}),
+        (b"font/woff2", {"font"}),
+        # 6.4. Matching an archive type pattern
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#matching-an-archive-type-pattern
+        (b"application/x-gzip", {"archive"}),
+        (b"application/zip", {"zip", "archive"}),
+        (b"application/x-rar-compressed", {"archive"}),
+        # 7. Determining the computed mime type of a resource
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#determining-the-computed-mime-type-of-a-resource
+        (b"unknown/unknown", {}),
+        (b"application/unknown", {}),
+        (b"*/*", {}),
+        # 7.1. Identifying a resource with an unknown MIME type
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#identifying-a-resource-with-an-unknown-mime-type
+        (b"text/html", {"html", "scriptable"}),
+        (b"application/postscript", {}),
+        (b"text/plain", {}),
         (b"application/octet-stream", {}),
+        # 7.3. Sniffing a mislabeled feed
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#sniffing-a-mislabeled-feed
+        (b"application/rss+xml", {"xml", "scriptable"}),
+        (b"application/atom+xml", {"xml", "scriptable"}),
+        # 8.8. Sniffing in a text track context
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#sniffing-in-a-text-track-context
+        (b"text/vtt", {}),
+        # 8.9. Sniffing in a cache manifest context
+        # https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#sniffing-in-a-cache-manifest-context
+        (b"text/cache-manifest", {}),
     ],
 )
 def test_mime_group(mime_type, mime_groups):

--- a/tests/test_mimegroups.py
+++ b/tests/test_mimegroups.py
@@ -1,56 +1,38 @@
-from xtractmime.mimegroups import (
-    is_archive_mime_type,
-    is_audio_video_mime_type,
-    is_font_mime_type,
-    is_html_mime_type,
-    is_image_mime_type,
-    is_javascript_mime_type,
-    is_json_mime_type,
-    is_scriptable_mime_type,
-    is_xml_mime_type,
-    is_zip_based_mime_type,
+import pytest
+
+from xtractmime import mimegroups
+
+
+ALL_MIME_GROUPS = {
+    name[3:-10]: getattr(mimegroups, name)
+    for name in dir(mimegroups)
+    if name.startswith("is_") and name.endswith("_mime_type")
+}
+
+
+@pytest.mark.parametrize(
+    "mime_type,mime_groups",
+    [
+        (b"image/foo", {"image"}),
+        (b"audio/foo", {"audio_video"}),
+        (b"video/foo", {"audio_video"}),
+        (b"application/ogg", {"audio_video"}),
+        (b"font/foo", {"font"}),
+        (b"application/font-cff", {"font"}),
+        (b"application/foo+zip", {"zip"}),
+        (b"application/zip", {"zip", "archive"}),
+        (b"application/x-gzip", {"archive"}),
+        (b"application/foo+xml", {"xml", "scriptable"}),
+        (b"text/xml", {"xml", "scriptable"}),
+        (b"text/html", {"html", "scriptable"}),
+        (b"application/pdf", {"scriptable"}),
+        (b"application/ecmascript", {"javascript"}),
+        (b"application/foo+json", {"json"}),
+        (b"text/json", {"json"}),
+    ],
 )
-
-
-class TestMimegroups:
-    def test_is_archive_mime_type(self):
-        assert is_archive_mime_type(b"application/zip")
-        assert not is_archive_mime_type(b"text/test")
-
-    def test_is_audio_video_mime_type(self):
-        assert is_audio_video_mime_type(b"video/mp4")
-        assert not is_audio_video_mime_type(b"text/test")
-
-    def test_is_font_mime_type(self):
-        assert is_font_mime_type(b"application/font-cff")
-        assert not is_font_mime_type(b"text/test")
-
-    def test_is_html_mime_type(self):
-        assert is_html_mime_type(b"text/html")
-        assert not is_html_mime_type(b"text/test")
-
-    def test_is_image_mime_type(self):
-        assert is_image_mime_type(b"image/gif")
-        assert not is_image_mime_type(b"text/test")
-
-    def test_is_javascript_mime_type(self):
-        assert is_javascript_mime_type(b"application/javascript")
-        assert not is_javascript_mime_type(b"text/test")
-
-    def test_is_json_mime_type(self):
-        assert is_json_mime_type(b"text/json")
-        assert not is_json_mime_type(b"text/test")
-
-    def test_is_scriptable_mime_type(self):
-        assert is_scriptable_mime_type(b"text/html")
-        assert is_scriptable_mime_type(b"text/xml")
-        assert is_scriptable_mime_type(b"application/pdf")
-        assert not is_scriptable_mime_type(b"text/test")
-
-    def test_is_xml_mime_type(self):
-        assert is_xml_mime_type(b"text/xml")
-        assert not is_xml_mime_type(b"text/test")
-
-    def test_is_zip_based_mime_type(self):
-        assert is_zip_based_mime_type(b"application/zip")
-        assert not is_zip_based_mime_type(b"text/test")
+def test_mime_group(mime_type, mime_groups):
+    assert all(
+        is_in_mime_group(mime_type) == (mime_group in mime_groups)
+        for mime_group, is_in_mime_group in ALL_MIME_GROUPS.items()
+    )

--- a/tests/test_mimegroups.py
+++ b/tests/test_mimegroups.py
@@ -34,8 +34,9 @@ ALL_MIME_GROUPS = {
         (b"application/foo+json", {"json"}),
         (b"text/json", {"json"}),
         (b"application/postscript", {"text"}),
-        (b"text/plain", {"text"}),
-        (b"text/plain; charset=ISO-8859-1", {"text"}),
+        (b"text/plain", {}),
+        (b"text/plain; charset=ISO-8859-1", {}),
+        (b"application/octet-stream", {}),
     ],
 )
 def test_mime_group(mime_type, mime_groups):

--- a/xtractmime/__init__.py
+++ b/xtractmime/__init__.py
@@ -9,6 +9,7 @@ from xtractmime._utils import (
     get_image_mime,
     get_text_mime,
 )
+from xtractmime.mimegroups import is_audio_video_mime_type, is_html_mime_type, is_image_mime_type
 
 
 def _find_unknown_mimetype(
@@ -202,17 +203,16 @@ def extract_mime(
     if supplied_type.endswith(b"+xml") or supplied_type in {b"text/xml", b"application/xml"}:
         return supplied_type
 
-    if supplied_type == b"text/html":
+    if is_html_mime_type(supplied_type):
         return _sniff_mislabled_feed(resource_header, supplied_type)
 
     if supported_types:
-        if supplied_type.startswith(b"image/"):
+        if is_image_mime_type(supplied_type):
             matched_type = get_image_mime(resource_header)
             if matched_type in supported_types:
                 return matched_type
 
-        video_types = (b"audio/", b"video/")
-        if supplied_type.startswith(video_types) or supplied_type == b"application/ogg":
+        if is_audio_video_mime_type(supplied_type):
             matched_type = get_audio_video_mime(resource_header)
             if matched_type in supported_types:
                 return matched_type

--- a/xtractmime/_patterns.py
+++ b/xtractmime/_patterns.py
@@ -1,12 +1,5 @@
 from typing import Optional, Set, Tuple
 
-_APACHE_TYPES = [
-    b"text/plain",
-    b"text/plain; charset=ISO-8859-1",
-    b"text/plain; charset=iso-8859-1",
-    b"text/plain; charset=UTF-8",
-]
-WHITESPACE_BYTES = {b"\t", b"\r", b"\x0c", b"\n", b" "}
 
 #: Section 3
 #: https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#terminology  # noqa: E501
@@ -39,6 +32,51 @@ BINARY_BYTES = (
     b"\x1e",
     b"\x1f",
 )
+WHITESPACE_BYTES = {b"\t", b"\r", b"\x0c", b"\n", b" "}
+
+#: Section 4.6
+#: https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#mime-type-groups  # noqa: E501
+FONT_TYPES = [
+    b"application/font-cff",
+    b"application/font-off",
+    b"application/font-sfnt",
+    b"application/font-ttf",
+    b"application/font-woff",
+    b"application/vnd.ms-fontobject",
+    b"application/vnd.ms-opentype",
+]
+ARCHIVE_TYPES = [
+    b"application/x-rar-compressed",
+    b"application/zip",
+    b"application/x-gzip",
+]
+JAVASCRIPT_TYPES = [
+    b"application/ecmascript",
+    b"application/javascript",
+    b"application/x-ecmascript",
+    b"application/x-javascript",
+    b"text/ecmascript",
+    b"text/javascript",
+    b"text/javascript1.0",
+    b"text/javascript1.1",
+    b"text/javascript1.2",
+    b"text/javascript1.3",
+    b"text/javascript1.4",
+    b"text/javascript1.5",
+    b"text/jscript",
+    b"text/livescript",
+    b"text/x-ecmascript",
+    b"text/x-javascript",
+]
+
+#: Section 5.1, step 2
+#: https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#interpreting-the-resource-metadata  # noqa: E501
+_APACHE_TYPES = [
+    b"text/plain",
+    b"text/plain; charset=ISO-8859-1",
+    b"text/plain; charset=iso-8859-1",
+    b"text/plain; charset=UTF-8",
+]
 
 #: Section 6.1, step 1
 #: https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#matching-an-image-type-pattern  # noqa: E501

--- a/xtractmime/mimegroups.py
+++ b/xtractmime/mimegroups.py
@@ -1,0 +1,78 @@
+from _patterns import ARCHIVE_TYPES, FONT_TYPES, JAVASCRIPT_TYPES
+
+
+def is_image_mime_type(mime_type: bytes) -> bool:
+    if mime_type.startswith(b"image/"):
+        return True
+
+    return False
+
+
+def is_audio_video_mime_type(mime_type: bytes) -> bool:
+    video_types = (b"audio/", b"video/")
+    if mime_type.startswith(video_types) or mime_type == b"application/ogg":
+        return True
+
+    return False
+
+
+def is_font_mime_type(mime_type: bytes) -> bool:
+    if mime_type.startswith(b"font/") or mime_type in FONT_TYPES:
+        return True
+
+    return False
+
+
+def is_zip_based_mime_type(mime_type: bytes) -> bool:
+    if mime_type.endswith(b"+zip") or mime_type == b"application/zip":
+        return True
+
+    return False
+
+
+def is_archive_mime_type(mime_type: bytes) -> bool:
+    if mime_type in ARCHIVE_TYPES:
+        return True
+
+    return False
+
+
+def is_xml_mime_type(mime_type: bytes) -> bool:
+    if mime_type.endswith(b"+xml") or mime_type in (b"text/xml", b"application/xml"):
+        return True
+
+    return False
+
+
+def is_html_mime_type(mime_type: bytes) -> bool:
+    if mime_type == b"text/html":
+        return True
+
+    return False
+
+
+def is_scriptable_mime_type(mime_type: bytes) -> bool:
+    if is_xml_mime_type(mime_type):
+        return True
+
+    if is_html_mime_type(mime_type):
+        return True
+
+    if mime_type == b"application/pdf":
+        return True
+
+    return False
+
+
+def is_javascript_mime_type(mime_type: bytes) -> bool:
+    if mime_type.lower() in JAVASCRIPT_TYPES:
+        return True
+
+    return False
+
+
+def is_json_mime_type(mime_type: bytes) -> bool:
+    if mime_type.endswith(b"+json") or mime_type in (b"application/json", b"text/json"):
+        return True
+
+    return False

--- a/xtractmime/mimegroups.py
+++ b/xtractmime/mimegroups.py
@@ -1,7 +1,5 @@
 from xtractmime._patterns import (
-    _APACHE_TYPES,
     ARCHIVE_TYPES,
-    EXTRA_PATTERNS,
     FONT_TYPES,
     JAVASCRIPT_TYPES,
 )
@@ -52,8 +50,3 @@ def is_javascript_mime_type(mime_type: bytes) -> bool:
 
 def is_json_mime_type(mime_type: bytes) -> bool:
     return mime_type.endswith(b"+json") or mime_type in (b"application/json", b"text/json")
-
-
-def is_text_mime_type(mime_type: bytes) -> bool:
-    text_types = tuple(text_type[3] for text_type in EXTRA_PATTERNS)
-    return mime_type in _APACHE_TYPES or mime_type in text_types

--- a/xtractmime/mimegroups.py
+++ b/xtractmime/mimegroups.py
@@ -1,54 +1,33 @@
-from _patterns import ARCHIVE_TYPES, FONT_TYPES, JAVASCRIPT_TYPES
+from xtractmime._patterns import ARCHIVE_TYPES, FONT_TYPES, JAVASCRIPT_TYPES
 
 
 def is_image_mime_type(mime_type: bytes) -> bool:
-    if mime_type.startswith(b"image/"):
-        return True
-
-    return False
+    return mime_type.startswith(b"image/")
 
 
 def is_audio_video_mime_type(mime_type: bytes) -> bool:
     video_types = (b"audio/", b"video/")
-    if mime_type.startswith(video_types) or mime_type == b"application/ogg":
-        return True
-
-    return False
+    return mime_type.startswith(video_types) or mime_type == b"application/ogg"
 
 
 def is_font_mime_type(mime_type: bytes) -> bool:
-    if mime_type.startswith(b"font/") or mime_type in FONT_TYPES:
-        return True
-
-    return False
+    return mime_type.startswith(b"font/") or mime_type in FONT_TYPES
 
 
 def is_zip_based_mime_type(mime_type: bytes) -> bool:
-    if mime_type.endswith(b"+zip") or mime_type == b"application/zip":
-        return True
-
-    return False
+    return mime_type.endswith(b"+zip") or mime_type == b"application/zip"
 
 
 def is_archive_mime_type(mime_type: bytes) -> bool:
-    if mime_type in ARCHIVE_TYPES:
-        return True
-
-    return False
+    return mime_type in ARCHIVE_TYPES
 
 
 def is_xml_mime_type(mime_type: bytes) -> bool:
-    if mime_type.endswith(b"+xml") or mime_type in (b"text/xml", b"application/xml"):
-        return True
-
-    return False
+    return mime_type.endswith(b"+xml") or mime_type in (b"text/xml", b"application/xml")
 
 
 def is_html_mime_type(mime_type: bytes) -> bool:
-    if mime_type == b"text/html":
-        return True
-
-    return False
+    return mime_type == b"text/html"
 
 
 def is_scriptable_mime_type(mime_type: bytes) -> bool:
@@ -58,21 +37,12 @@ def is_scriptable_mime_type(mime_type: bytes) -> bool:
     if is_html_mime_type(mime_type):
         return True
 
-    if mime_type == b"application/pdf":
-        return True
-
-    return False
+    return mime_type == b"application/pdf"
 
 
 def is_javascript_mime_type(mime_type: bytes) -> bool:
-    if mime_type.lower() in JAVASCRIPT_TYPES:
-        return True
-
-    return False
+    return mime_type.lower() in JAVASCRIPT_TYPES
 
 
 def is_json_mime_type(mime_type: bytes) -> bool:
-    if mime_type.endswith(b"+json") or mime_type in (b"application/json", b"text/json"):
-        return True
-
-    return False
+    return mime_type.endswith(b"+json") or mime_type in (b"application/json", b"text/json")

--- a/xtractmime/mimegroups.py
+++ b/xtractmime/mimegroups.py
@@ -1,4 +1,10 @@
-from xtractmime._patterns import ARCHIVE_TYPES, FONT_TYPES, JAVASCRIPT_TYPES
+from xtractmime._patterns import (
+    _APACHE_TYPES,
+    ARCHIVE_TYPES,
+    EXTRA_PATTERNS,
+    FONT_TYPES,
+    JAVASCRIPT_TYPES,
+)
 
 
 def is_image_mime_type(mime_type: bytes) -> bool:
@@ -46,3 +52,8 @@ def is_javascript_mime_type(mime_type: bytes) -> bool:
 
 def is_json_mime_type(mime_type: bytes) -> bool:
     return mime_type.endswith(b"+json") or mime_type in (b"application/json", b"text/json")
+
+
+def is_text_mime_type(mime_type: bytes) -> bool:
+    text_types = tuple(text_type[3] for text_type in EXTRA_PATTERNS)
+    return mime_type in _APACHE_TYPES or mime_type in text_types

--- a/xtractmime/mimegroups.py
+++ b/xtractmime/mimegroups.py
@@ -14,7 +14,7 @@ def is_font_mime_type(mime_type: bytes) -> bool:
     return mime_type.startswith(b"font/") or mime_type in FONT_TYPES
 
 
-def is_zip_based_mime_type(mime_type: bytes) -> bool:
+def is_zip_mime_type(mime_type: bytes) -> bool:
     return mime_type.endswith(b"+zip") or mime_type == b"application/zip"
 
 


### PR DESCRIPTION
This PR will add the functionality to xtractmime for determining mime group based on supplied content type.

Implemented [Section 4.6](https://mimesniff.spec.whatwg.org/commit-snapshots/609a3a3c935fbb805b46cf3d90768d695a1dcff2/#mime-type-groups)