### PR TITLE
Missing tests for extract_mime()

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,6 +54,8 @@ class TestMain:
                         >
                         </rdf:RDF>"""
 
+    extra_types = ((b"test", b"\xff\xff\xff\xff", None, b"text/test"),)
+
     @pytest.mark.parametrize(
         "body,content_types,http_origin,no_sniff,extra_types,supported_types,expected",
         [
@@ -70,8 +72,8 @@ class TestMain:
             (b"", (b"text/html; charset=utf-8",), True, False, None, None, b"text/html"),
             (b"", (b"text/htmlpdfthing",), True, False, None, None, b"text/htmlpdfthing"),
             (b"", None, True, False, None, None, b"text/plain"),
-            (b"test", None, True, False, ((b"test", b"\xff\xff\xff\xff", None, b"text/test"),), None, b"text/test"),
-            (b"TEST", None, True, False, ((b"test", b"\xff\xff\xff\xff", None, b"text/test"),), None, b"text/plain"),
+            (b"test", None, True, False, extra_types, None, b"text/test",),
+            (b"TEST", None, True, False, extra_types, None, b"text/plain",),
         ],
     )
     def test_extract_mime(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -55,23 +55,27 @@ class TestMain:
                         </rdf:RDF>"""
 
     @pytest.mark.parametrize(
-        "body,content_types,http_origin,no_sniff,supported_types,expected",
+        "body,content_types,http_origin,no_sniff,extra_types,supported_types,expected",
         [
-            ("foo.pdf", None, True, False, None, b"application/pdf"),
-            ("foo.gif", (b"image/gif",), True, True, None, b"image/gif"),
-            ("foo.txt", (b"text/plain",), True, False, None, b"text/plain"),
-            ("foo.xml", (b"text/xml",), True, False, None, b"text/xml"),
-            ("foo.html", (b"text/html",), True, False, None, b"text/html"),
-            ("foo.gif", (b"image/gif",), True, False, (b"image/gif",), b"image/gif"),
-            ("foo.mp4", (b"video/mp4",), True, False, (b"video/mp4",), b"video/mp4"),
-            (b"\x00\x00\x00\x00", (b"text/test",), True, False, None, b"text/test"),
-            (b"", (b"text/html; charset=utf-8",), True, False, None, b"text/html"),
-            (b"", (b"text/htmlpdfthing",), True, False, None, b"text/htmlpdfthing"),
-            (b"", None, True, False, None, b"text/plain"),
+            ("foo.pdf", None, True, False, None, None, b"application/pdf"),
+            ("foo.gif", (b"image/gif",), True, True, None, None, b"image/gif"),
+            ("foo.txt", (b"text/plain",), True, False, None, None, b"text/plain"),
+            ("foo.xml", (b"text/xml",), True, False, None, None, b"text/xml"),
+            ("foo.html", (b"text/html",), True, False, None, None, b"text/html"),
+            ("foo.gif", (b"image/gif",), True, False, None, (b"image/gif",), b"image/gif"),
+            ("foo.mp4", (b"video/mp4",), True, False, None, (b"video/mp4",), b"video/mp4"),
+            (b"GIF87a", (b"image/gif",), True, False, None, (b"image/x-icon",), b"image/gif"),
+            (b"ID3", (b"audio/mpeg",), True, False, None, (b"audio/basic",), b"audio/mpeg"),
+            (b"\x00\x00\x00\x00", (b"text/test",), True, False, None, None, b"text/test"),
+            (b"", (b"text/html; charset=utf-8",), True, False, None, None, b"text/html"),
+            (b"", (b"text/htmlpdfthing",), True, False, None, None, b"text/htmlpdfthing"),
+            (b"", None, True, False, None, None, b"text/plain"),
+            (b"test", None, True, False, ((b"test", b"\xff\xff\xff\xff", None, b"text/test"),), None, b"text/test"),
+            (b"TEST", None, True, False, ((b"test", b"\xff\xff\xff\xff", None, b"text/test"),), None, b"text/plain"),
         ],
     )
     def test_extract_mime(
-        self, body, content_types, http_origin, no_sniff, supported_types, expected
+        self, body, content_types, http_origin, no_sniff, extra_types, supported_types, expected
     ):
         if isinstance(body, str):
             with open(f"tests/files/{body}", "rb") as input_file:
@@ -82,6 +86,7 @@ class TestMain:
                 content_types=content_types,
                 http_origin=http_origin,
                 no_sniff=no_sniff,
+                extra_types=extra_types,
                 supported_types=supported_types,
             )
             == expected


### PR DESCRIPTION
Added some missings tests for the function `xtractmime.extract_mime()` related to the parameters `extra_types` & `supported_types`