### PR TITLE
Fix Apache bug flag handling

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -74,6 +74,15 @@ class TestMain:
             (b"", (b"text/htmlpdfthing",), True, False, None, None, b"text/htmlpdfthing"),
             (b"", None, True, False, None, None, b"text/plain"),
             (
+                b"\x00\x01\xff",
+                (b"text/plain; charset=windows-1252",),
+                True,
+                False,
+                None,
+                None,
+                b"text/plain",
+            ),
+            (
                 b"test",
                 None,
                 True,

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 [testenv:typing]
 basepython = python3
 deps =
-    mypy==0.780
+    mypy==0.910
 commands =
     mypy --show-error-codes --ignore-missing-imports \
         --follow-imports=skip {posargs: xtractmime setup.py tests}

--- a/xtractmime/__init__.py
+++ b/xtractmime/__init__.py
@@ -198,8 +198,8 @@ def extract_mime(
 ) -> Optional[bytes]:
     extra_types = extra_types or tuple()
     supplied_type = content_types[-1] if content_types else b""
-    supplied_type = supplied_type.split(b";")[0].strip().lower()
     check_for_apache = http_origin and supplied_type in _APACHE_TYPES
+    supplied_type = supplied_type.split(b";")[0].strip().lower()
     resource_header = memoryview(body)[:RESOURCE_HEADER_BUFFER_LENGTH]
 
     if supplied_type in (b"", b"unknown/unknown", b"application/unknown", b"*/*"):


### PR DESCRIPTION
Will only set `check_for_apache` flag only if `supplied_type` belongs to one of `text/plain`, `text/plain; charset=ISO-8859-1`, `text/plain; charset=iso-8859-1`, `text/plain; charset=UTF-8`

Fixes #13 