### PR TITLE
Ignore invalid supplied MIME types

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -127,6 +127,8 @@ class TestMain:
                     ),
                 )
             ),
+            # Malformed MIME type
+            (b"...", (b"javascript charset=UTF-8",), True, False, None, None, b"text/plain"),
         ],
     )
     def test_extract_mime(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -128,10 +128,15 @@ class TestMain:
                 )
             ),
             # Malformed MIME type
-            (b"...", (b"javascript charset=UTF-8",), True, False, None, None, b"text/plain"),
-            (b"...", (b"a/b/c",), True, False, None, None, b"text/plain"),
-            (b"...", (b"a/[",), True, False, None, None, b"text/plain"),
-            (b"...", (b"[/a",), True, False, None, None, b"text/plain"),
+            *(
+                (b"...", (mime_type,), True, False, None, None, b"text/plain")
+                for mime_type in (
+                    b"javascript charset=UTF-8",
+                    b"a/b/c",
+                    b"a/[",
+                    b"[/a",
+                )
+            ),
         ],
     )
     def test_extract_mime(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -129,6 +129,9 @@ class TestMain:
             ),
             # Malformed MIME type
             (b"...", (b"javascript charset=UTF-8",), True, False, None, None, b"text/plain"),
+            (b"...", (b"a/b/c",), True, False, None, None, b"text/plain"),
+            (b"...", (b"a/[",), True, False, None, None, b"text/plain"),
+            (b"...", (b"[/a",), True, False, None, None, b"text/plain"),
         ],
     )
     def test_extract_mime(

--- a/xtractmime/__init__.py
+++ b/xtractmime/__init__.py
@@ -188,7 +188,7 @@ def _sniff_mislabled_feed(input_bytes: bytes, supplied_type: bytes) -> Optional[
     return supplied_type
 
 
-_TOKEN = br"^\s*[-!#$%&'*+.0-9A-Z^_`a-z{|}~]+\s*$"
+_TOKEN = rb"^\s*[-!#$%&'*+.0-9A-Z^_`a-z{|}~]+\s*$"
 
 
 def _is_valid_mime_type(mime_type):


### PR DESCRIPTION
Based on a real-world scenario found as part of https://github.com/scrapy/scrapy/pull/5204#issuecomment-1871871231.

According to the standard, step 5 in https://mimesniff.spec.whatwg.org/#interpreting-the-resource-metadata:

> If supplied-type is not a [MIME type](https://mimesniff.spec.whatwg.org/#mime-type), the [supplied MIME type](https://mimesniff.spec.whatwg.org/#supplied-mime-type) is undefined.